### PR TITLE
Create bilingual ACY Securities personal site

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="بهاء العموش، مدير علاقات في ACY Securities الأردن. حلول تداول مخصصة، كاش باك VIP، دعم أولوية، وخدمات إيداع وسحب سريعة.">
+  <meta name="keywords" content="ACY Securities, بهاء العموش, تداول, إدارة علاقات, الأردن, فوركس, VIP">
+  <title>ACY Securities | بهاء العموش</title>
+  <meta property="og:title" content="ACY Securities | بهاء العموش">
+  <meta property="og:description" content="اكتشف حلول التداول المخصصة مع بهاء العموش، مدير العلاقات في ACY Securities الأردن.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://bahaaalamoush.github.io">
+  <meta property="og:locale" content="ar_AR">
+  <link rel="stylesheet" href="./style.css">
+  <script defer src="./script.js"></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "ACY Securities | Baha'a Alamoush",
+    "description": "Relationship management and VIP trading services in Jordan.",
+    "image": "https://via.placeholder.com/800x600?text=ACY+Securities",
+    "address": {
+      "@type": "PostalAddress",
+      "addressCountry": "JO"
+    },
+    "telephone": "+962792229139",
+    "url": "https://bahaaalamoush.github.io",
+    "makesOffer": [{
+      "@type": "Offer",
+      "name": "Cashback $10 per lot",
+      "priceCurrency": "USD"
+    }]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "ما هي أوقات معالجة الإيداع؟",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "الإيداعات عبر Gate2Pay وVisa تكون عادة فورية، بينما التحويلات البنكية تحتاج تأكيد من الفريق المختص."}
+      },
+      {
+        "@type": "Question",
+        "name": "ما متطلبات التحقق؟",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "يلزم تقديم هوية سارية العنوان وإثبات عنوان لضمان الامتثال التنظيمي."}
+      },
+      {
+        "@type": "Question",
+        "name": "هل توجد حدود إيداع أو سحب؟",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "تطبق حدود يومية للعملاء الجدد ويتم تخصيصها حسب تصنيف الحساب."}
+      }
+    ]
+  }
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">تخطي إلى المحتوى</a>
+  <div class="top-bar" aria-hidden="true">
+    <span>ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.</span>
+  </div>
+  <header class="site-header" id="top">
+    <div class="brand-group">
+      <div class="logo" aria-hidden="true">
+        <svg viewBox="0 0 120 40" role="img" aria-labelledby="logoTitle">
+          <title id="logoTitle">ACY Securities</title>
+          <rect x="0" y="0" width="120" height="40" rx="8" fill="#0c0c0f" stroke="#bfa355" stroke-width="2"></rect>
+          <text x="50%" y="55%" text-anchor="middle" fill="#f5f5f5" font-family="'Cairo', sans-serif" font-size="18">ACY</text>
+        </svg>
+      </div>
+      <div>
+        <h1>ACY Securities | بهاء العموش</h1>
+        <p class="subtitle" data-i18n="subtitle">مدير علاقات في الأردن</p>
+      </div>
+    </div>
+    <nav class="quick-actions" aria-label="روابط سريعة">
+      <button class="lang-toggle" id="languageToggle" aria-label="تغيير اللغة" data-i18n="langToggle">English</button>
+      <a href="#contact" class="action-btn" data-i18n="callNow">اتصال فوري</a>
+      <a href="https://wa.me/962792229139" class="action-btn" target="_blank" rel="noopener" data-i18n="whatsapp">تواصل عبر واتساب</a>
+      <a href="https://www.instagram.com/bahaa_omoush" class="action-btn" target="_blank" rel="noopener" data-i18n="instagram">إنستغرام</a>
+      <a href="https://www.linkedin.com/in/bahaaalamoush" class="action-btn" target="_blank" rel="noopener" data-i18n="linkedin">لينكدإن</a>
+      <button class="motion-toggle" id="motionToggle" aria-pressed="false" data-i18n="motionToggle">إيقاف الحركة</button>
+    </nav>
+  </header>
+  <main id="main-content" class="main">
+    <section class="hero" id="hero" data-section>
+      <div class="hero-text" data-section>
+        <h2 data-i18n="heroTitle">بهاء العموش، مدير علاقات في ACY Securities</h2>
+        <p class="hero-sub" data-i18n="heroSubtitle">نرافقك في كل خطوة استثمارية مع حلول مصممة لاحتياجاتك.</p>
+        <ul class="benefit-list" data-i18n-group="heroBullets">
+          <li>$10 لكل لوت كاش باك بشروط واضحة</li>
+          <li>4% على كل 50 ألف إيداع صافٍ لعملاء VIP</li>
+          <li>تنفيذ إيداع سريع وسحب سلس</li>
+          <li>فروقات سعرية منخفضة وتنفيذ سريع</li>
+          <li>دعم أولوية ومدير علاقات مخصص</li>
+        </ul>
+        <div class="cta-group">
+          <a href="#contact" class="primary-cta" data-i18n="ctaStart">ابدأ الآن</a>
+          <a href="mailto:bahaa.alamoush@acy.com" class="secondary-cta" data-i18n="ctaCall">احجز مكالمة قصيرة</a>
+        </div>
+      </div>
+      <div class="hero-visual" aria-hidden="true">
+        <div class="glow-card">
+          <span data-i18n="heroVisual">حلول تداول حصرية</span>
+        </div>
+      </div>
+      <div class="regulation-note" data-i18n="regulation">
+        ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.
+      </div>
+    </section>
+
+    <section class="benefits" id="benefits" data-section>
+      <header>
+        <h2 data-i18n="benefitsTitle">مزايا رئيسية لعملائك</h2>
+        <p data-i18n="benefitsSubtitle">كل بطاقة تعرض التفاصيل والاشتراطات بنقرة واحدة.</p>
+      </header>
+      <div class="cards-grid">
+        <article class="benefit-card" data-modal="cashback">
+          <h3 data-i18n="benefitCashback">كاش باك $10 لكل لوت</h3>
+          <p data-i18n="benefitCashbackDesc">استرداد نقدي دوري للعملاء النشطين.</p>
+        </article>
+        <article class="benefit-card" data-modal="vip">
+          <h3 data-i18n="benefitVIP">VIP 4% على كل 50 ألف</h3>
+          <p data-i18n="benefitVIPDesc">مكافآت مخصصة لأصحاب الإيداعات العالية.</p>
+        </article>
+        <article class="benefit-card" data-modal="deposit">
+          <h3 data-i18n="benefitDeposit">تنفيذ إيداع سريع</h3>
+          <p data-i18n="benefitDepositDesc">خيارات متعددة محلية ودولية.</p>
+        </article>
+        <article class="benefit-card" data-modal="bonus">
+          <h3 data-i18n="benefitBonus">مكافآت مؤهلة</h3>
+          <p data-i18n="benefitBonusDesc">عروض خاصة وفق معايير الامتثال.</p>
+        </article>
+        <article class="benefit-card" data-modal="spreads">
+          <h3 data-i18n="benefitSpreads">فروقات منخفضة</h3>
+          <p data-i18n="benefitSpreadsDesc">تنفيذ سريع وتسعير شفاف.</p>
+        </article>
+        <article class="benefit-card" data-modal="support">
+          <h3 data-i18n="benefitSupport">دعم أولوية</h3>
+          <p data-i18n="benefitSupportDesc">خطوط مباشرة وفريق متكامل.</p>
+        </article>
+      </div>
+      <div class="modal" id="modal-cashback" role="dialog" aria-modal="true" aria-labelledby="modal-cashback-title" aria-hidden="true">
+        <div class="modal-content">
+          <button class="close-modal" aria-label="إغلاق">×</button>
+          <h4 id="modal-cashback-title" data-i18n="modalCashbackTitle">شروط الكاش باك</h4>
+          <p data-i18n="modalCashbackText">متاح للحسابات المفعلة بإيداع أولي مع الحد الأدنى لنشاط التداول الشهري. يتم الدفع بالدولار الأمريكي.</p>
+        </div>
+      </div>
+      <div class="modal" id="modal-vip" role="dialog" aria-modal="true" aria-labelledby="modal-vip-title" aria-hidden="true">
+        <div class="modal-content">
+          <button class="close-modal" aria-label="إغلاق">×</button>
+          <h4 id="modal-vip-title" data-i18n="modalVipTitle">شروط برنامج VIP</h4>
+          <p data-i18n="modalVipText">يتم تقييم صافي الإيداع شهرياً، مع ضرورة استيفاء معايير الامتثال والتصنيف المناسب.</p>
+        </div>
+      </div>
+      <div class="modal" id="modal-deposit" role="dialog" aria-modal="true" aria-labelledby="modal-deposit-title" aria-hidden="true">
+        <div class="modal-content">
+          <button class="close-modal" aria-label="إغلاق">×</button>
+          <h4 id="modal-deposit-title" data-i18n="modalDepositTitle">خيارات الإيداع</h4>
+          <p data-i18n="modalDepositText">يدعم Gate2Pay وUSDT وVisa والتحويل البنكي، مع متابعة مباشرة حتى التأكيد.</p>
+        </div>
+      </div>
+      <div class="modal" id="modal-bonus" role="dialog" aria-modal="true" aria-labelledby="modal-bonus-title" aria-hidden="true">
+        <div class="modal-content">
+          <button class="close-modal" aria-label="إغلاق">×</button>
+          <h4 id="modal-bonus-title" data-i18n="modalBonusTitle">مكافآت مؤهلة</h4>
+          <p data-i18n="modalBonusText">تنطبق الشروط والأحكام بناءً على نوع الحساب والنشاط، وتتطلب مراجعة قانونية.</p>
+        </div>
+      </div>
+      <div class="modal" id="modal-spreads" role="dialog" aria-modal="true" aria-labelledby="modal-spreads-title" aria-hidden="true">
+        <div class="modal-content">
+          <button class="close-modal" aria-label="إغلاق">×</button>
+          <h4 id="modal-spreads-title" data-i18n="modalSpreadsTitle">فروقات الأسعار</h4>
+          <p data-i18n="modalSpreadsText">تطبق فروقات متغيرة تنافسية مع تنفيذ STP وخيارات حماية متقدمة.</p>
+        </div>
+      </div>
+      <div class="modal" id="modal-support" role="dialog" aria-modal="true" aria-labelledby="modal-support-title" aria-hidden="true">
+        <div class="modal-content">
+          <button class="close-modal" aria-label="إغلاق">×</button>
+          <h4 id="modal-support-title" data-i18n="modalSupportTitle">الدعم والأولوية</h4>
+          <p data-i18n="modalSupportText">يشمل خطوط مخصصة ومتابعة على مدار الساعة بالتعاون مع مكاتب الأردن وأستراليا.</p>
+        </div>
+      </div>
+      <div class="regulation-note" data-i18n="regulation">
+        ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.
+      </div>
+    </section>
+
+    <section class="timeline" id="timeline" data-section>
+      <header>
+        <h2 data-i18n="timelineTitle">جدول الإيداع والسحب</h2>
+        <p data-i18n="timelineSubtitle">تابع الخطوات حتى التأكيد النهائي.</p>
+      </header>
+      <div class="timeline-track">
+        <div class="timeline-step" data-step="1">
+          <h3 data-i18n="timelineStep1">طلب الإيداع</h3>
+          <p data-i18n="timelineStep1Desc">يتم استلام الطلب والتحقق من المستندات فوراً.</p>
+        </div>
+        <div class="timeline-step" data-step="2">
+          <h3 data-i18n="timelineStep2">التنفيذ</h3>
+          <p data-i18n="timelineStep2Desc">التنفيذ عبر Gate2Pay أو Visa أو USDT أو التحويل البنكي.</p>
+        </div>
+        <div class="timeline-step" data-step="3">
+          <h3 data-i18n="timelineStep3">التأكيد</h3>
+          <p data-i18n="timelineStep3Desc">تأكيد السجل وإشعار العميل مع متابعة من مدير العلاقات.</p>
+        </div>
+      </div>
+      <div class="faq" id="faq">
+        <h3 data-i18n="faqTitle">أسئلة شائعة</h3>
+        <details>
+          <summary data-i18n="faqProcessing">أوقات المعالجة</summary>
+          <p data-i18n="faqProcessingText">Gate2Pay وVisa عادة فورية، أما التحويل البنكي فيستغرق 1-2 يوم عمل حسب البنك.</p>
+        </details>
+        <details>
+          <summary data-i18n="faqVerification">التحقق</summary>
+          <p data-i18n="faqVerificationText">يتطلب تقديم هوية رسمية وإثبات عنوان ساري لضمان الامتثال.</p>
+        </details>
+        <details>
+          <summary data-i18n="faqLimits">الحدود</summary>
+          <p data-i18n="faqLimitsText">تطبق حدود مرنة حسب الملف الشخصي مع إمكانية زيادتها بعد مراجعة الفريق.</p>
+        </details>
+      </div>
+      <div class="regulation-note" data-i18n="regulation">
+        ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.
+      </div>
+    </section>
+
+    <section class="calculator" id="cashback" data-section>
+      <header>
+        <h2 data-i18n="calculatorTitle">حاسبة الكاش باك</h2>
+        <p data-i18n="calculatorSubtitle">أدخل عدد اللوت المتوقع شهرياً.</p>
+      </header>
+      <label for="lotInput" data-i18n="calculatorLabel">عدد اللوت شهرياً</label>
+      <input type="number" id="lotInput" min="0" step="1" inputmode="numeric" placeholder="0">
+      <div class="result" id="cashbackResult" data-i18n="calculatorResult">تقدير الكاش باك: 0 دولار</div>
+      <p class="disclosure" data-i18n="calculatorDisclosure">هذا تقدير عام ويعتمد على نوع الحساب والشروط.</p>
+      <div class="regulation-note" data-i18n="regulation">
+        ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.
+      </div>
+    </section>
+
+    <section class="vip" id="vip" data-section>
+      <header>
+        <h2 data-i18n="vipTitle">VIP 4% على كل 50 ألف إيداع صافٍ</h2>
+        <p data-i18n="vipSubtitle">حرّك الشريط لمعرفة مستوى الاستحقاق.</p>
+      </header>
+      <label for="vipSlider" data-i18n="vipSliderLabel">صافي الإيداع (دولار)</label>
+      <input type="range" id="vipSlider" min="0" max="200000" step="5000" value="50000">
+      <div class="vip-progress">
+        <div class="vip-progress-bar" id="vipProgress"></div>
+      </div>
+      <div class="vip-value" id="vipValue" data-i18n="vipValue">قيمة مكافأة تقديرية: 2000 دولار</div>
+      <p class="disclosure" data-i18n="vipDisclosure">يتم التقييم شهرياً، الشروط والحدود تنطبق.</p>
+      <a href="#contact" class="primary-cta" data-i18n="vipCTA">تحدث معي الآن</a>
+      <div class="regulation-note" data-i18n="regulation">
+        ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.
+      </div>
+    </section>
+
+    <section class="testimonials" id="testimonials" data-section>
+      <header>
+        <h2 data-i18n="testimonialsTitle">ماذا يقول العملاء</h2>
+        <p data-i18n="testimonialsSubtitle">آراء حقيقية من متداولين محترفين.</p>
+      </header>
+      <div class="carousel" aria-live="polite">
+        <div class="carousel-track">
+          <figure class="testimonial">
+            <blockquote data-i18n="testimonial1">"تم تنفيذ الإيداعات خلال دقائق وحصلنا على الكاش باك دون تأخير."</blockquote>
+            <figcaption data-i18n="testimonial1Author">فريق تداول مؤسسي</figcaption>
+          </figure>
+          <figure class="testimonial">
+            <blockquote data-i18n="testimonial2">"الدعم الشخصي من بهاء منحنا وضوحاً في كل حملة ترويجية."</blockquote>
+            <figcaption data-i18n="testimonial2Author">مكتب استشارات مالية</figcaption>
+          </figure>
+          <figure class="testimonial">
+            <blockquote data-i18n="testimonial3">"برامج VIP جذبت عملاء جدد مع شروط شفافة."</blockquote>
+            <figcaption data-i18n="testimonial3Author">شريك توزيع</figcaption>
+          </figure>
+        </div>
+      </div>
+      <div class="regulation-note" data-i18n="regulation">
+        ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.
+      </div>
+    </section>
+
+    <section class="contact" id="contact" data-section>
+      <header>
+        <h2 data-i18n="contactTitle">ابدأ التواصل الآن</h2>
+        <p data-i18n="contactSubtitle">املأ النموذج وسيتم التواصل معك في أقرب وقت.</p>
+      </header>
+      <form id="leadForm">
+        <div class="form-row">
+          <label for="name" data-i18n="formName">الاسم</label>
+          <input type="text" id="name" required>
+        </div>
+        <div class="form-row">
+          <label for="phone" data-i18n="formPhone">رقم الهاتف</label>
+          <input type="tel" id="phone" required>
+        </div>
+        <div class="form-row">
+          <label for="email" data-i18n="formEmail">البريد الإلكتروني</label>
+          <input type="email" id="email" required>
+        </div>
+        <div class="form-row">
+          <label for="platform" data-i18n="formPlatform">المنصة المفضلة</label>
+          <input type="text" id="platform" placeholder="MT4 / MT5 / cTrader">
+        </div>
+        <div class="form-row">
+          <label for="deposit" data-i18n="formDeposit">نطاق الإيداع المتوقع</label>
+          <select id="deposit">
+            <option value="" data-i18n="formDepositSelect">اختر نطاقاً</option>
+            <option value="0-10k">0 - 10,000</option>
+            <option value="10k-50k">10,000 - 50,000</option>
+            <option value="50k-100k">50,000 - 100,000</option>
+            <option value="100k+">100,000+</option>
+          </select>
+        </div>
+        <div class="form-row checkbox">
+          <label>
+            <input type="checkbox" id="consent" required>
+            <span data-i18n="formConsent">أوافق على التواصل لاستلام معلومات المنتجات والعروض.</span>
+          </label>
+        </div>
+        <button type="submit" class="primary-cta" data-i18n="formSubmit">إرسال</button>
+        <div id="formMessage" role="status" aria-live="polite"></div>
+      </form>
+      <div class="contact-lines">
+        <p><strong data-i18n="contactPhoneLabel">هاتف:</strong> <a href="tel:+962792229139">+962792229139</a></p>
+        <p><strong data-i18n="contactEmailLabel">البريد:</strong> <a href="mailto:bahaa.alamoush@acy.com">bahaa.alamoush@acy.com</a></p>
+        <p><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/bahaaalamoush" target="_blank" rel="noopener">linkedin.com/in/bahaaalamoush</a></p>
+        <p><strong>Instagram:</strong> <a href="https://www.instagram.com/bahaa_omoush" target="_blank" rel="noopener">@bahaa_omoush</a></p>
+      </div>
+      <div class="regulation-note" data-i18n="regulation">
+        ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.
+      </div>
+    </section>
+  </main>
+
+  <div class="disclaimer-ribbon" aria-live="polite" data-i18n="disclaimerRibbon">Trading CFDs involves risk of loss. التداول بالعقود مقابل الفروقات قد يعرضك لخسارة رأس المال.</div>
+
+  <footer class="site-footer">
+    <div class="footer-content">
+      <p data-i18n="footerRights">© 2024 ACY Securities Jordan. جميع الحقوق محفوظة.</p>
+      <p data-i18n="footerCompliance">ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.</p>
+    </div>
+  </footer>
+
+  <div class="chat-widget" id="chatWidget" aria-live="polite">
+    <button class="chat-toggle" id="chatToggle" aria-expanded="false">
+      <span data-i18n="chatButton">تحدث مع بهاء</span>
+    </button>
+    <div class="chat-window" id="chatWindow" role="dialog" aria-modal="false" aria-labelledby="chatTitle" tabindex="-1">
+      <div class="chat-header">
+        <h3 id="chatTitle" data-i18n="chatTitle">دردشة مباشرة</h3>
+        <button class="close-chat" aria-label="إغلاق">×</button>
+      </div>
+      <div class="chat-body">
+        <p class="chat-note" data-i18n="regulation">ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.</p>
+        <p data-i18n="chatWelcome">أهلاً بك، يسعدني دعمك في تفعيل حسابك مع ACY Securities.</p>
+        <form id="chatForm">
+          <label for="chatName" data-i18n="chatName">الاسم</label>
+          <input type="text" id="chatName" required>
+          <label for="chatPhone" data-i18n="chatPhone">رقم الهاتف</label>
+          <input type="tel" id="chatPhone" required>
+          <button type="submit" class="primary-cta" data-i18n="chatSubmit">إرسال</button>
+        </form>
+        <div id="chatMessage" role="status" aria-live="assertive"></div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,460 @@
+const translations = {
+  ar: {
+    subtitle: "مدير علاقات في الأردن",
+    langToggle: "English",
+    callNow: "اتصال فوري",
+    whatsapp: "تواصل عبر واتساب",
+    instagram: "إنستغرام",
+    linkedin: "لينكدإن",
+    motionToggle: "إيقاف الحركة",
+    heroTitle: "بهاء العموش، مدير علاقات في ACY Securities",
+    heroSubtitle: "نرافقك في كل خطوة استثمارية مع حلول مصممة لاحتياجاتك.",
+    heroVisual: "حلول تداول حصرية",
+    heroBullets: [
+      "$10 لكل لوت كاش باك بشروط واضحة",
+      "4% على كل 50 ألف إيداع صافٍ لعملاء VIP",
+      "تنفيذ إيداع سريع وسحب سلس",
+      "فروقات سعرية منخفضة وتنفيذ سريع",
+      "دعم أولوية ومدير علاقات مخصص"
+    ],
+    ctaStart: "ابدأ الآن",
+    ctaCall: "احجز مكالمة قصيرة",
+    regulation: "ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.",
+    benefitsTitle: "مزايا رئيسية لعملائك",
+    benefitsSubtitle: "كل بطاقة تعرض التفاصيل والاشتراطات بنقرة واحدة.",
+    benefitCashback: "كاش باك $10 لكل لوت",
+    benefitCashbackDesc: "استرداد نقدي دوري للعملاء النشطين.",
+    benefitVIP: "VIP 4% على كل 50 ألف",
+    benefitVIPDesc: "مكافآت مخصصة لأصحاب الإيداعات العالية.",
+    benefitDeposit: "تنفيذ إيداع سريع",
+    benefitDepositDesc: "خيارات متعددة محلية ودولية.",
+    benefitBonus: "مكافآت مؤهلة",
+    benefitBonusDesc: "عروض خاصة وفق معايير الامتثال.",
+    benefitSpreads: "فروقات منخفضة",
+    benefitSpreadsDesc: "تنفيذ سريع وتسعير شفاف.",
+    benefitSupport: "دعم أولوية",
+    benefitSupportDesc: "خطوط مباشرة وفريق متكامل.",
+    modalCashbackTitle: "شروط الكاش باك",
+    modalCashbackText: "متاح للحسابات المفعلة بإيداع أولي مع الحد الأدنى لنشاط التداول الشهري. يتم الدفع بالدولار الأمريكي.",
+    modalVipTitle: "شروط برنامج VIP",
+    modalVipText: "يتم تقييم صافي الإيداع شهرياً، مع ضرورة استيفاء معايير الامتثال والتصنيف المناسب.",
+    modalDepositTitle: "خيارات الإيداع",
+    modalDepositText: "يدعم Gate2Pay وUSDT وVisa والتحويل البنكي، مع متابعة مباشرة حتى التأكيد.",
+    modalBonusTitle: "مكافآت مؤهلة",
+    modalBonusText: "تنطبق الشروط والأحكام بناءً على نوع الحساب والنشاط، وتتطلب مراجعة قانونية.",
+    modalSpreadsTitle: "فروقات الأسعار",
+    modalSpreadsText: "تطبق فروقات متغيرة تنافسية مع تنفيذ STP وخيارات حماية متقدمة.",
+    modalSupportTitle: "الدعم والأولوية",
+    modalSupportText: "يشمل خطوط مخصصة ومتابعة على مدار الساعة بالتعاون مع مكاتب الأردن وأستراليا.",
+    timelineTitle: "جدول الإيداع والسحب",
+    timelineSubtitle: "تابع الخطوات حتى التأكيد النهائي.",
+    timelineStep1: "طلب الإيداع",
+    timelineStep1Desc: "يتم استلام الطلب والتحقق من المستندات فوراً.",
+    timelineStep2: "التنفيذ",
+    timelineStep2Desc: "التنفيذ عبر Gate2Pay أو Visa أو USDT أو التحويل البنكي.",
+    timelineStep3: "التأكيد",
+    timelineStep3Desc: "تأكيد السجل وإشعار العميل مع متابعة من مدير العلاقات.",
+    faqTitle: "أسئلة شائعة",
+    faqProcessing: "أوقات المعالجة",
+    faqProcessingText: "Gate2Pay وVisa عادة فورية، أما التحويل البنكي فيستغرق 1-2 يوم عمل حسب البنك.",
+    faqVerification: "التحقق",
+    faqVerificationText: "يتطلب تقديم هوية رسمية وإثبات عنوان ساري لضمان الامتثال.",
+    faqLimits: "الحدود",
+    faqLimitsText: "تطبق حدود مرنة حسب الملف الشخصي مع إمكانية زيادتها بعد مراجعة الفريق.",
+    calculatorTitle: "حاسبة الكاش باك",
+    calculatorSubtitle: "أدخل عدد اللوت المتوقع شهرياً.",
+    calculatorLabel: "عدد اللوت شهرياً",
+    calculatorResult: "تقدير الكاش باك: {value} دولار",
+    calculatorDisclosure: "هذا تقدير عام ويعتمد على نوع الحساب والشروط.",
+    vipTitle: "VIP 4% على كل 50 ألف إيداع صافٍ",
+    vipSubtitle: "حرّك الشريط لمعرفة مستوى الاستحقاق.",
+    vipSliderLabel: "صافي الإيداع (دولار)",
+    vipValue: "قيمة مكافأة تقديرية: {value} دولار",
+    vipDisclosure: "يتم التقييم شهرياً، الشروط والحدود تنطبق.",
+    vipCTA: "تحدث معي الآن",
+    testimonialsTitle: "ماذا يقول العملاء",
+    testimonialsSubtitle: "آراء حقيقية من متداولين محترفين.",
+    testimonial1: "\"تم تنفيذ الإيداعات خلال دقائق وحصلنا على الكاش باك دون تأخير.\"",
+    testimonial1Author: "فريق تداول مؤسسي",
+    testimonial2: "\"الدعم الشخصي من بهاء منحنا وضوحاً في كل حملة ترويجية.\"",
+    testimonial2Author: "مكتب استشارات مالية",
+    testimonial3: "\"برامج VIP جذبت عملاء جدد مع شروط شفافة.\"",
+    testimonial3Author: "شريك توزيع",
+    contactTitle: "ابدأ التواصل الآن",
+    contactSubtitle: "املأ النموذج وسيتم التواصل معك في أقرب وقت.",
+    formName: "الاسم",
+    formPhone: "رقم الهاتف",
+    formEmail: "البريد الإلكتروني",
+    formPlatform: "المنصة المفضلة",
+    formDeposit: "نطاق الإيداع المتوقع",
+    formDepositSelect: "اختر نطاقاً",
+    formConsent: "أوافق على التواصل لاستلام معلومات المنتجات والعروض.",
+    formSubmit: "إرسال",
+    formSuccess: "تم إرسال البيانات بنجاح، سيتم التواصل قريباً.",
+    contactPhoneLabel: "هاتف:",
+    contactEmailLabel: "البريد:",
+    footerRights: "© {year} ACY Securities Jordan. جميع الحقوق محفوظة.",
+    footerCompliance: "ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.",
+    chatButton: "تحدث مع بهاء",
+    chatTitle: "دردشة مباشرة",
+    chatWelcome: "أهلاً بك، يسعدني دعمك في تفعيل حسابك مع ACY Securities.",
+    chatName: "الاسم",
+    chatPhone: "رقم الهاتف",
+    chatSubmit: "إرسال",
+    chatSuccess: "شكراً {name}، سأتواصل معك على {phone}.",
+    disclaimerRibbon: "Trading CFDs involves risk of loss. التداول بالعقود مقابل الفروقات قد يعرضك لخسارة رأس المال.",
+    motionEnable: "تفعيل الحركة",
+    formMailSubject: "استفسار عميل جديد",
+    formMailBody: "الاسم: {name}\nالهاتف: {phone}\nالبريد: {email}\nالمنصة: {platform}\nنطاق الإيداع: {deposit}"
+  },
+  en: {
+    subtitle: "Relationship Manager in Jordan",
+    langToggle: "العربية",
+    callNow: "Call Now",
+    whatsapp: "WhatsApp",
+    instagram: "Instagram",
+    linkedin: "LinkedIn",
+    motionToggle: "Disable Motion",
+    heroTitle: "Baha’a Alamoush, Relationship Manager at ACY Securities",
+    heroSubtitle: "A dedicated partner for every stage of your trading journey.",
+    heroVisual: "Exclusive Trading Solutions",
+    heroBullets: [
+      "$10 cashback per lot with clear conditions",
+      "4% on every 50K net deposit for VIP clients",
+      "Rapid funding execution and smooth withdrawals",
+      "Tight spreads with lightning execution",
+      "Priority support with a dedicated manager"
+    ],
+    ctaStart: "Start Now",
+    ctaCall: "Book a Brief Call",
+    regulation: "ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.",
+    benefitsTitle: "Flagship Advantages for Your Clients",
+    benefitsSubtitle: "Tap each card to uncover conditions and fine print.",
+    benefitCashback: "$10 Cashback per Lot",
+    benefitCashbackDesc: "Recurring rebates for active accounts.",
+    benefitVIP: "VIP 4% Every 50K",
+    benefitVIPDesc: "Tailored rewards for higher deposits.",
+    benefitDeposit: "Fast Deposit Execution",
+    benefitDepositDesc: "Diverse local and global rails.",
+    benefitBonus: "Qualified Bonuses",
+    benefitBonusDesc: "Compliance-approved promotional offers.",
+    benefitSpreads: "Low Spreads",
+    benefitSpreadsDesc: "Transparent pricing with swift fills.",
+    benefitSupport: "Priority Support",
+    benefitSupportDesc: "Direct lines and a full coverage desk.",
+    modalCashbackTitle: "Cashback Conditions",
+    modalCashbackText: "Available for activated accounts meeting the monthly trading activity threshold. Paid in USD.",
+    modalVipTitle: "VIP Program Conditions",
+    modalVipText: "Net deposits are reviewed monthly with eligibility tied to compliance status.",
+    modalDepositTitle: "Funding Options",
+    modalDepositText: "Gate2Pay, USDT, Visa, and bank wires with live follow-up until confirmation.",
+    modalBonusTitle: "Qualified Bonuses",
+    modalBonusText: "Offers depend on account type and activity and require legal approval.",
+    modalSpreadsTitle: "Pricing and Spreads",
+    modalSpreadsText: "Competitive variable spreads with STP execution and protection tools.",
+    modalSupportTitle: "Priority Coverage",
+    modalSupportText: "Dedicated lines with round-the-clock coordination across Jordan and Australia.",
+    timelineTitle: "Deposit and Withdrawal Journey",
+    timelineSubtitle: "Track each step until confirmation.",
+    timelineStep1: "Funding Request",
+    timelineStep1Desc: "We capture the request and verify documents instantly.",
+    timelineStep2: "Execution",
+    timelineStep2Desc: "Processed via Gate2Pay, Visa, USDT, or bank transfer.",
+    timelineStep3: "Confirmation",
+    timelineStep3Desc: "Ledger updated and client notified with RM follow-up.",
+    faqTitle: "Frequently Asked Questions",
+    faqProcessing: "Processing Times",
+    faqProcessingText: "Gate2Pay and Visa are typically instant while bank wires take 1-2 business days.",
+    faqVerification: "Verification",
+    faqVerificationText: "Submit valid ID and proof of address to stay compliant.",
+    faqLimits: "Limits",
+    faqLimitsText: "Flexible limits tailored to your profile with upgrades after review.",
+    calculatorTitle: "Cashback Calculator",
+    calculatorSubtitle: "Enter your expected monthly lots.",
+    calculatorLabel: "Lots per Month",
+    calculatorResult: "Cashback estimate: {value} USD",
+    calculatorDisclosure: "Indicative only. Final value depends on account type and conditions.",
+    vipTitle: "VIP 4% on Every 50K Net Deposit",
+    vipSubtitle: "Adjust the slider to see potential rewards.",
+    vipSliderLabel: "Net Deposit (USD)",
+    vipValue: "Estimated reward: {value} USD",
+    vipDisclosure: "Reviewed monthly. Conditions and limits apply.",
+    vipCTA: "Talk to Me Now",
+    testimonialsTitle: "What Clients Say",
+    testimonialsSubtitle: "Direct feedback from professional traders.",
+    testimonial1: "\"Deposits cleared within minutes and cashback arrived right away.\"",
+    testimonial1Author: "Institutional Trading Desk",
+    testimonial2: "\"Baha’a’s personal support made every promo rollout crystal clear.\"",
+    testimonial2Author: "Financial Advisory Office",
+    testimonial3: "\"VIP programs attracted new accounts with transparent terms.\"",
+    testimonial3Author: "Distribution Partner",
+    contactTitle: "Start the Conversation",
+    contactSubtitle: "Share your details and we will connect shortly.",
+    formName: "Name",
+    formPhone: "Phone",
+    formEmail: "Email",
+    formPlatform: "Preferred Platform",
+    formDeposit: "Expected Funding Range",
+    formDepositSelect: "Select a range",
+    formConsent: "I agree to be contacted with product information and offers.",
+    formSubmit: "Submit",
+    formSuccess: "Submitted successfully. Expect a follow-up shortly.",
+    contactPhoneLabel: "Phone:",
+    contactEmailLabel: "Email:",
+    footerRights: "© {year} ACY Securities Jordan. All rights reserved.",
+    footerCompliance: "ACY Securities Pty Ltd is regulated by ASIC. AFSL No. [insert]. Operations in Jordan in partnership with Al Bilad Securities and Investment Co. [insert exact local disclosure]. Trading CFDs involves risk of loss. Not investment advice.",
+    chatButton: "Chat with Baha’a",
+    chatTitle: "Live Chat",
+    chatWelcome: "Welcome. I am here to activate your ACY Securities account.",
+    chatName: "Name",
+    chatPhone: "Phone",
+    chatSubmit: "Send",
+    chatSuccess: "Thank you {name}, I will reach you on {phone}.",
+    disclaimerRibbon: "Trading CFDs involves risk of loss. التداول بالعقود مقابل الفروقات قد يعرضك لخسارة رأس المال.",
+    motionEnable: "Enable Motion",
+    formMailSubject: "New client enquiry",
+    formMailBody: "Name: {name}\nPhone: {phone}\nEmail: {email}\nPlatform: {platform}\nDeposit range: {deposit}"
+  }
+};
+
+const state = {
+  locale: 'ar',
+  motionEnabled: true
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  const body = document.body;
+  const html = document.documentElement;
+  const languageToggle = document.getElementById('languageToggle');
+  const motionToggle = document.getElementById('motionToggle');
+  const lotInput = document.getElementById('lotInput');
+  const cashbackResult = document.getElementById('cashbackResult');
+  const vipSlider = document.getElementById('vipSlider');
+  const vipProgress = document.getElementById('vipProgress');
+  const vipValue = document.getElementById('vipValue');
+  const leadForm = document.getElementById('leadForm');
+  const formMessage = document.getElementById('formMessage');
+  const chatWidget = document.getElementById('chatWidget');
+  const chatToggle = document.getElementById('chatToggle');
+  const chatWindow = document.getElementById('chatWindow');
+  const chatClose = chatWindow.querySelector('.close-chat');
+  const chatForm = document.getElementById('chatForm');
+  const chatMessage = document.getElementById('chatMessage');
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  if (prefersReducedMotion.matches) {
+    body.classList.add('motion-off');
+    state.motionEnabled = false;
+    updateMotionToggleText();
+  }
+
+  const motionChangeHandler = (event) => {
+    state.motionEnabled = !event.matches;
+    body.classList.toggle('motion-off', event.matches);
+    updateMotionToggleText();
+  };
+
+  if (typeof prefersReducedMotion.addEventListener === 'function') {
+    prefersReducedMotion.addEventListener('change', motionChangeHandler);
+  } else if (typeof prefersReducedMotion.addListener === 'function') {
+    prefersReducedMotion.addListener(motionChangeHandler);
+  }
+
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.2 });
+
+  document.querySelectorAll('[data-section]').forEach(section => {
+    observer.observe(section);
+  });
+
+  applyTranslations();
+  updateCalculator();
+  updateVip();
+
+  if (languageToggle) {
+    languageToggle.addEventListener('click', () => {
+      state.locale = state.locale === 'ar' ? 'en' : 'ar';
+      applyTranslations();
+      const isEnglish = state.locale === 'en';
+      html.lang = isEnglish ? 'en' : 'ar';
+      html.dir = isEnglish ? 'ltr' : 'rtl';
+      body.classList.toggle('lang-en', isEnglish);
+    });
+  }
+
+  if (motionToggle) {
+    motionToggle.addEventListener('click', () => {
+      state.motionEnabled = !state.motionEnabled;
+      body.classList.toggle('motion-off', !state.motionEnabled);
+      updateMotionToggleText();
+    });
+  }
+
+  function updateMotionToggleText() {
+    const key = state.motionEnabled ? 'motionToggle' : 'motionEnable';
+    if (motionToggle) {
+      motionToggle.textContent = translations[state.locale][key];
+      motionToggle.setAttribute('aria-pressed', (!state.motionEnabled).toString());
+    }
+  }
+
+  if (lotInput) {
+    lotInput.addEventListener('input', updateCalculator);
+  }
+
+  function updateCalculator() {
+    const value = Math.max(Number(lotInput?.value || 0), 0);
+    const cashback = (value * 10).toLocaleString(state.locale === 'ar' ? 'ar' : 'en-US');
+    if (cashbackResult) {
+      const template = translations[state.locale].calculatorResult;
+      cashbackResult.textContent = template.replace('{value}', cashback);
+    }
+  }
+
+  if (vipSlider) {
+    vipSlider.addEventListener('input', updateVip);
+  }
+
+  function updateVip() {
+    const value = Number(vipSlider?.value || 0);
+    const reward = (value * 0.04).toLocaleString(state.locale === 'ar' ? 'ar' : 'en-US', { maximumFractionDigits: 0 });
+    if (vipProgress) {
+      const max = Number(vipSlider?.max || 1);
+      const percentage = Math.min(100, Math.round((value / max) * 100));
+      vipProgress.style.width = `${percentage}%`;
+    }
+    if (vipValue) {
+      const template = translations[state.locale].vipValue;
+      vipValue.textContent = template.replace('{value}', reward);
+    }
+  }
+
+  const cards = document.querySelectorAll('.benefit-card');
+  const modals = document.querySelectorAll('.modal');
+
+  cards.forEach(card => {
+    card.addEventListener('click', () => {
+      const modalId = card.getAttribute('data-modal');
+      if (!modalId) return;
+      const modal = document.getElementById(`modal-${modalId}`);
+      if (modal) {
+        modal.classList.add('show');
+        modal.setAttribute('aria-hidden', 'false');
+      }
+    });
+  });
+
+  modals.forEach(modal => {
+    modal.addEventListener('click', (event) => {
+      if (event.target.classList.contains('modal') || event.target.classList.contains('close-modal')) {
+        closeModal(modal);
+      }
+    });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      modals.forEach(closeModal);
+    }
+  });
+
+  function closeModal(modal) {
+    modal.classList.remove('show');
+    modal.setAttribute('aria-hidden', 'true');
+  }
+
+  if (leadForm) {
+    leadForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const name = document.getElementById('name').value.trim();
+      const phone = document.getElementById('phone').value.trim();
+      const email = document.getElementById('email').value.trim();
+      const platform = document.getElementById('platform').value.trim();
+      const deposit = document.getElementById('deposit').value || translations[state.locale].formDepositSelect;
+      if (formMessage) {
+        formMessage.textContent = translations[state.locale].formSuccess;
+      }
+      const subject = encodeURIComponent(translations[state.locale].formMailSubject);
+      const bodyTemplate = translations[state.locale].formMailBody;
+      const bodyFilled = bodyTemplate
+        .replace('{name}', name)
+        .replace('{phone}', phone)
+        .replace('{email}', email)
+        .replace('{platform}', platform || '-')
+        .replace('{deposit}', deposit || '-');
+      const mailBody = encodeURIComponent(bodyFilled);
+      window.location.href = `mailto:bahaa.alamoush@acy.com?subject=${subject}&body=${mailBody}`;
+      leadForm.reset();
+    });
+  }
+
+  if (chatToggle) {
+    chatToggle.addEventListener('click', () => {
+      const isOpen = chatWidget.classList.toggle('open');
+      chatToggle.setAttribute('aria-expanded', isOpen.toString());
+      if (isOpen) {
+        chatWindow.focus();
+      }
+    });
+  }
+
+  if (chatClose) {
+    chatClose.addEventListener('click', () => {
+      chatWidget.classList.remove('open');
+      chatToggle.setAttribute('aria-expanded', 'false');
+    });
+  }
+
+  if (chatForm) {
+    chatForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const name = document.getElementById('chatName').value.trim();
+      const phone = document.getElementById('chatPhone').value.trim();
+      const template = translations[state.locale].chatSuccess;
+      chatMessage.textContent = template.replace('{name}', name).replace('{phone}', phone);
+      chatForm.reset();
+    });
+  }
+
+  function applyTranslations() {
+    const localeStrings = translations[state.locale];
+    document.querySelectorAll('[data-i18n]').forEach(node => {
+      const key = node.getAttribute('data-i18n');
+      const template = localeStrings[key];
+      if (!template) return;
+      let value = template;
+      if (key === 'footerRights') {
+        value = value.replace('{year}', new Date().getFullYear());
+      }
+      node.textContent = value;
+    });
+
+    document.querySelectorAll('[data-i18n-group]').forEach(node => {
+      const key = node.getAttribute('data-i18n-group');
+      const items = localeStrings[key];
+      if (Array.isArray(items)) {
+        node.innerHTML = items.map(item => `<li>${item}</li>`).join('');
+      }
+    });
+
+    updateCalculator();
+    updateVip();
+    updateMotionToggleText();
+
+    const isEnglish = state.locale === 'en';
+    document.documentElement.lang = isEnglish ? 'en' : 'ar';
+    document.documentElement.dir = isEnglish ? 'ltr' : 'rtl';
+    document.body.classList.toggle('lang-en', isEnglish);
+  }
+
+  window.addEventListener('resize', () => {
+    observer.disconnect();
+    document.querySelectorAll('[data-section]:not(.visible)').forEach(section => observer.observe(section));
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,647 @@
+:root {
+  color-scheme: dark;
+  --bg: #0c0c0f;
+  --fg: #f5f5f5;
+  --muted: #b0b0b0;
+  --gold: #bfa355;
+  --card-bg: #141418;
+  --border: rgba(191, 163, 85, 0.35);
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+  font-family: 'Cairo', 'Tajawal', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(191, 163, 85, 0.12), transparent 45%), var(--bg);
+  color: var(--fg);
+  font-size: 1rem;
+  line-height: 1.6;
+  min-height: 100vh;
+  transition: background 0.6s ease;
+}
+
+body.lang-en {
+  direction: ltr;
+  text-align: left;
+}
+
+body.lang-en .main section {
+  text-align: left;
+}
+
+body.lang-en .benefit-list,
+body.lang-en .hero-text {
+  text-align: left;
+}
+
+body.motion-off *,
+body.motion-off *::before,
+body.motion-off *::after {
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.001ms !important;
+  scroll-behavior: auto !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--gold);
+  color: #000;
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 0.5rem 0.5rem;
+  z-index: 999;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+.top-bar {
+  background: rgba(12, 12, 15, 0.9);
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.site-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem clamp(1rem, 4vw, 3rem);
+  backdrop-filter: blur(12px);
+  background: rgba(12, 12, 15, 0.85);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 900;
+}
+
+.brand-group {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  margin: 0;
+}
+
+.quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.action-btn,
+.lang-toggle,
+.motion-toggle {
+  border: 1px solid var(--gold);
+  background: transparent;
+  color: var(--fg);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.3s ease, background 0.3s ease;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.action-btn:hover,
+.lang-toggle:hover,
+.motion-toggle:hover,
+.primary-cta:hover,
+.secondary-cta:hover {
+  background: var(--gold);
+  color: #000;
+  transform: translateY(-2px);
+}
+
+.primary-cta,
+.secondary-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.primary-cta {
+  background: var(--gold);
+  color: #000;
+  box-shadow: 0 10px 20px rgba(191, 163, 85, 0.25);
+}
+
+.secondary-cta {
+  border: 1px solid var(--gold);
+  color: var(--fg);
+}
+
+.main {
+  padding: 2rem clamp(1rem, 6vw, 5rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
+}
+
+section header > h2 {
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  margin: 0 0 0.5rem 0;
+}
+
+section header > p {
+  color: var(--muted);
+  margin: 0 0 1.5rem 0;
+}
+
+[data-section] {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+[data-section].visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+}
+
+.hero-text {
+  background: linear-gradient(135deg, rgba(191, 163, 85, 0.1), transparent 70%);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-text::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(191, 163, 85, 0.25);
+  border-radius: inherit;
+  opacity: 0.4;
+}
+
+.hero-sub {
+  color: var(--muted);
+}
+
+.benefit-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.benefit-list li {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(20, 20, 24, 0.8);
+  border: 1px solid rgba(191, 163, 85, 0.2);
+  position: relative;
+  overflow: hidden;
+}
+
+.benefit-list li::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(191, 163, 85, 0.25), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.benefit-list li:hover::before {
+  opacity: 1;
+}
+
+.hero-visual {
+  display: flex;
+  justify-content: center;
+}
+
+.glow-card {
+  width: min(320px, 80vw);
+  aspect-ratio: 3 / 4;
+  border-radius: 1.5rem;
+  background: radial-gradient(circle at top, rgba(191, 163, 85, 0.25), rgba(12, 12, 15, 0.95));
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(191, 163, 85, 0.4);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+  font-size: 1.3rem;
+  text-align: center;
+  padding: 2rem;
+  letter-spacing: 0.05em;
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.benefit-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  cursor: pointer;
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.benefit-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(191, 163, 85, 0.35), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.benefit-card:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow);
+}
+
+.benefit-card:hover::after {
+  opacity: 1;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(12, 12, 15, 0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 950;
+}
+
+.modal.show {
+  display: flex;
+}
+
+.modal-content {
+  background: #101014;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  max-width: 420px;
+  width: 100%;
+  padding: 2rem;
+  box-shadow: var(--shadow);
+}
+
+.close-modal,
+.close-chat {
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.timeline-track {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  position: relative;
+}
+
+.timeline-track::before {
+  content: "";
+  position: absolute;
+  top: 0.5rem;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(191, 163, 85, 0.6), transparent);
+  transform: translateY(-100%);
+}
+
+.timeline-step {
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: rgba(20, 20, 24, 0.85);
+  border: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+}
+
+.timeline-step::before {
+  content: attr(data-step);
+  position: absolute;
+  top: 1rem;
+  inset-inline-end: 1rem;
+  font-size: 2rem;
+  color: rgba(191, 163, 85, 0.3);
+}
+
+.faq details {
+  background: rgba(16, 16, 20, 0.9);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.faq summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.calculator input,
+.vip input[type="range"],
+form input,
+form select,
+form button {
+  width: 100%;
+}
+
+.calculator input,
+form input,
+form select {
+  background: rgba(20, 20, 24, 0.8);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: var(--fg);
+  font-size: 1rem;
+}
+
+.form-row {
+  margin-bottom: 1rem;
+}
+
+.form-row.checkbox {
+  display: flex;
+}
+
+.form-row.checkbox label {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.calculator .result,
+.vip-value,
+.disclosure {
+  margin-top: 1rem;
+  color: var(--muted);
+}
+
+.vip-progress {
+  background: rgba(20, 20, 24, 0.8);
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  height: 12px;
+  overflow: hidden;
+  margin: 1rem 0;
+}
+
+.vip-progress-bar {
+  background: linear-gradient(90deg, rgba(191, 163, 85, 0.9), rgba(255, 255, 255, 0.5));
+  height: 100%;
+  width: 0;
+  transition: width 0.6s ease;
+}
+
+.carousel {
+  overflow: hidden;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border);
+  background: rgba(16, 16, 20, 0.85);
+}
+
+.carousel-track {
+  display: flex;
+  width: max-content;
+  animation: slide 15s infinite linear;
+}
+
+.carousel:hover .carousel-track {
+  animation-play-state: paused;
+}
+
+.testimonial {
+  width: min(320px, 70vw);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.testimonial blockquote {
+  margin: 0;
+  font-style: italic;
+}
+
+.contact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.contact-lines p {
+  margin: 0.5rem 0;
+}
+
+.site-footer {
+  background: rgba(12, 12, 15, 0.95);
+  border-top: 1px solid var(--border);
+  padding: 2rem clamp(1rem, 4vw, 3rem);
+}
+
+.footer-content {
+  display: grid;
+  gap: 0.75rem;
+  color: var(--muted);
+}
+
+.chat-widget {
+  position: fixed;
+  inset-inline-end: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 980;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.chat-toggle {
+  background: var(--gold);
+  color: #000;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.25rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 15px 30px rgba(191, 163, 85, 0.35);
+  transition: transform 0.4s ease;
+  animation: float-in 1s ease forwards;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.chat-widget.open .chat-toggle {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.chat-widget.open .chat-window {
+  display: block;
+}
+
+.chat-window {
+  display: none;
+  width: min(320px, 80vw);
+  background: rgba(16, 16, 20, 0.95);
+  border: 1px solid var(--border);
+  border-radius: 1rem 1rem 0.5rem 1rem;
+  margin-top: 0.5rem;
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  background: rgba(191, 163, 85, 0.1);
+}
+
+.chat-body {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.chat-note {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.disclaimer-ribbon {
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  background: rgba(191, 163, 85, 0.2);
+  color: var(--fg);
+  text-align: center;
+  padding: 0.5rem 1rem;
+  font-size: 0.85rem;
+  backdrop-filter: blur(8px);
+}
+
+.regulation-note {
+  margin-top: 2rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: rgba(16, 16, 20, 0.85);
+  border: 1px dashed rgba(191, 163, 85, 0.4);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+@keyframes slide {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-33.33%); }
+}
+
+@keyframes float-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header {
+    position: static;
+  }
+  .quick-actions {
+    justify-content: center;
+  }
+  .timeline-track::before {
+    display: none;
+  }
+  .timeline-track {
+    grid-template-columns: 1fr;
+  }
+}
+
+body.lang-en .site-header,
+body.lang-en .top-bar,
+body.lang-en .disclaimer-ribbon {
+  direction: ltr;
+  text-align: left;
+}
+
+body.lang-en .regulation-note,
+body.lang-en .chat-widget,
+body.lang-en .chat-window,
+body.lang-en .chat-body {
+  direction: ltr;
+  text-align: left;
+}
+
+body.lang-en .chat-widget {
+  align-items: flex-start;
+  inset-inline-end: auto;
+  inset-inline-start: 1.5rem;
+}
+
+body.lang-en .chat-widget.open .chat-window {
+  border-radius: 1rem 1rem 1rem 0.5rem;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(12, 12, 15, 0.7);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(191, 163, 85, 0.6);
+  border-radius: 999px;
+}


### PR DESCRIPTION
## Summary
- build an Arabic-first static site for Baha’a Alamoush with bilingual hero, product messaging, and compliance notices
- add benefit modals, funding timeline, cashback calculator, VIP slider, testimonials, and contact form with mailto handoff
- implement responsive styling, premium animations, language and motion toggles, and lightweight chat widget interactions

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68fa68097200832899203e3efbf44204