### PR TITLE
Refresh landing page styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,27 +1,76 @@
 :root {
   color-scheme: dark;
-  --bg: #0c0c0f;
-  --fg: #f5f5f5;
-  --muted: #b0b0b0;
-  --gold: #bfa355;
-  --card-bg: #141418;
-  --border: rgba(191, 163, 85, 0.35);
-  --shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
-  font-family: 'Cairo', 'Tajawal', 'Segoe UI', sans-serif;
+  --bg: #050d1a;
+  --bg-alt: rgba(15, 23, 42, 0.75);
+  --card: rgba(12, 18, 31, 0.9);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-hover: #0ea5e9;
+  --border: rgba(148, 163, 184, 0.28);
+  --shadow: 0 30px 60px rgba(8, 47, 73, 0.35);
+  --radius: 22px;
+  --transition: 0.3s ease;
+  --max-width: 1180px;
+  --fg: var(--text);
+  --gold: var(--accent);
+  --card-bg: var(--card);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
 }
 
 * {
   box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top, rgba(191, 163, 85, 0.12), transparent 45%), var(--bg);
+  min-height: 100vh;
+  background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.12), transparent 55%), var(--bg);
   color: var(--fg);
   font-size: 1rem;
   line-height: 1.6;
-  min-height: 100vh;
-  transition: background 0.6s ease;
+  transition: background 0.6s ease, color 0.6s ease;
+  scroll-behavior: smooth;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.wrapper {
+  width: min(92%, var(--max-width));
+  margin: 0 auto;
+  padding: 4rem 0;
+}
+
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+h1 {
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  margin-bottom: 0.75rem;
+}
+
+h2 {
+  font-size: clamp(1.7rem, 3vw, 2.3rem);
+  margin-bottom: 1.5rem;
+}
+
+h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.6rem;
+}
+
+p {
+  color: var(--muted);
+  margin-bottom: 1.1rem;
 }
 
 body.lang-en {
@@ -61,10 +110,10 @@ body.motion-off *::after {
   top: -40px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--gold);
-  color: #000;
-  padding: 0.5rem 1rem;
-  border-radius: 0 0 0.5rem 0.5rem;
+  background: var(--accent);
+  color: #0f172a;
+  padding: 0.55rem 1.1rem;
+  border-radius: 0 0 0.75rem 0.75rem;
   z-index: 999;
 }
 
@@ -73,12 +122,13 @@ body.motion-off *::after {
 }
 
 .top-bar {
-  background: rgba(12, 12, 15, 0.9);
+  background: rgba(10, 19, 33, 0.85);
   border-bottom: 1px solid var(--border);
   color: var(--muted);
-  padding: 0.5rem 1rem;
+  padding: 0.55rem 1rem;
   font-size: 0.85rem;
   text-align: center;
+  backdrop-filter: blur(18px);
 }
 
 .site-header {
@@ -86,10 +136,11 @@ body.motion-off *::after {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  padding: 1.5rem clamp(1rem, 4vw, 3rem);
-  backdrop-filter: blur(12px);
-  background: rgba(12, 12, 15, 0.85);
-  border-bottom: 1px solid var(--border);
+  gap: 1.25rem;
+  padding: 1.75rem clamp(1.25rem, 4vw, 3rem);
+  backdrop-filter: blur(18px);
+  background: rgba(7, 13, 26, 0.82);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
   position: sticky;
   top: 0;
   z-index: 900;
@@ -98,31 +149,37 @@ body.motion-off *::after {
 .brand-group {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 1.1rem;
+}
+
+.brand-group h1 {
+  margin: 0 0 0.4rem 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
 }
 
 .subtitle {
   color: var(--muted);
   margin: 0;
+  letter-spacing: 0.04em;
 }
 
 .quick-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.65rem;
   justify-content: flex-end;
 }
 
 .action-btn,
 .lang-toggle,
 .motion-toggle {
-  border: 1px solid var(--gold);
-  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.45);
   color: var(--fg);
-  padding: 0.5rem 1rem;
+  padding: 0.6rem 1.2rem;
   border-radius: 999px;
   cursor: pointer;
-  transition: transform 0.3s ease, background 0.3s ease;
+  transition: transform var(--transition), background var(--transition), border-color var(--transition);
   text-decoration: none;
   font-weight: 600;
 }
@@ -132,8 +189,9 @@ body.motion-off *::after {
 .motion-toggle:hover,
 .primary-cta:hover,
 .secondary-cta:hover {
-  background: var(--gold);
-  color: #000;
+  background: var(--accent);
+  color: #0f172a;
+  border-color: rgba(56, 189, 248, 0.6);
   transform: translateY(-2px);
 }
 
@@ -143,39 +201,77 @@ body.motion-off *::after {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  padding: 0.75rem 1.5rem;
+  padding: 0.85rem 1.8rem;
   border-radius: 999px;
   text-decoration: none;
   font-weight: 700;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.8rem;
+  background: var(--accent);
+  color: #0f172a;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.25);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 18px 30px rgba(14, 165, 233, 0.28);
+}
+
+.link-button {
+  display: inline-flex;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: var(--fg);
+  font-weight: 500;
+  transition: background var(--transition), border-color var(--transition), transform var(--transition);
+}
+
+.link-button:hover {
+  background: rgba(148, 163, 184, 0.12);
+  border-color: rgba(56, 189, 248, 0.4);
+  transform: translateY(-2px);
 }
 
 .primary-cta {
-  background: var(--gold);
-  color: #000;
-  box-shadow: 0 10px 20px rgba(191, 163, 85, 0.25);
+  background: var(--accent);
+  color: #0f172a;
+  box-shadow: 0 18px 30px rgba(56, 189, 248, 0.2);
 }
 
 .secondary-cta {
-  border: 1px solid var(--gold);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   color: var(--fg);
+  background: rgba(15, 23, 42, 0.4);
 }
 
 .main {
-  padding: 2rem clamp(1rem, 6vw, 5rem) 4rem;
+  width: min(92%, var(--max-width));
+  margin: 0 auto;
+  padding: 4rem 0 4.5rem;
   display: flex;
   flex-direction: column;
-  gap: 4rem;
+  gap: 4.5rem;
 }
 
 section header > h2 {
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
-  margin: 0 0 0.5rem 0;
+  font-size: clamp(1.9rem, 3vw, 2.6rem);
+  margin: 0 0 0.75rem 0;
 }
 
 section header > p {
   color: var(--muted);
-  margin: 0 0 1.5rem 0;
+  margin: 0 0 1.4rem 0;
 }
 
 [data-section] {
@@ -189,29 +285,43 @@ section header > p {
   transform: translateY(0);
 }
 
+
 .hero {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
+  gap: 1.75rem;
   align-items: center;
+  background: linear-gradient(135deg, rgba(21, 94, 117, 0.35), rgba(15, 23, 42, 0.6));
+  padding: 3rem clamp(1.5rem, 5vw, 3rem);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 }
 
 .hero-text {
-  background: linear-gradient(135deg, rgba(191, 163, 85, 0.1), transparent 70%);
-  padding: clamp(1.5rem, 4vw, 2.5rem);
-  border-radius: 1.5rem;
-  box-shadow: var(--shadow);
+  background: rgba(8, 16, 31, 0.6);
+  padding: clamp(1.8rem, 4vw, 2.7rem);
+  border-radius: calc(var(--radius) - 6px);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.2);
   position: relative;
   overflow: hidden;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
 }
 
 .hero-text::after {
   content: "";
   position: absolute;
   inset: 0;
-  border: 1px solid rgba(191, 163, 85, 0.25);
+  border: 1px solid rgba(56, 189, 248, 0.25);
   border-radius: inherit;
-  opacity: 0.4;
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .hero-sub {
@@ -227,10 +337,10 @@ section header > p {
 }
 
 .benefit-list li {
-  padding: 0.75rem 1rem;
-  border-radius: 1rem;
-  background: rgba(20, 20, 24, 0.8);
-  border: 1px solid rgba(191, 163, 85, 0.2);
+  padding: 0.9rem 1.2rem;
+  border-radius: 1.1rem;
+  background: rgba(11, 20, 34, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   position: relative;
   overflow: hidden;
 }
@@ -239,9 +349,9 @@ section header > p {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(90deg, rgba(191, 163, 85, 0.25), transparent);
+  background: linear-gradient(120deg, rgba(56, 189, 248, 0.3), transparent 70%);
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--transition);
 }
 
 .benefit-list li:hover::before {
@@ -256,31 +366,32 @@ section header > p {
 .glow-card {
   width: min(320px, 80vw);
   aspect-ratio: 3 / 4;
-  border-radius: 1.5rem;
-  background: radial-gradient(circle at top, rgba(191, 163, 85, 0.25), rgba(12, 12, 15, 0.95));
+  border-radius: calc(var(--radius) - 2px);
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.35), rgba(8, 16, 31, 0.95));
   display: grid;
   place-items: center;
-  border: 1px solid rgba(191, 163, 85, 0.4);
-  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  box-shadow: 0 32px 64px rgba(8, 47, 73, 0.45);
   font-size: 1.3rem;
   text-align: center;
   padding: 2rem;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
+  color: var(--accent);
 }
 
 .cards-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 1.5rem;
+  gap: 1.6rem;
 }
 
 .benefit-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border);
-  border-radius: 1.25rem;
-  padding: 1.5rem;
+  background: rgba(7, 13, 26, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: calc(var(--radius) - 8px);
+  padding: 1.6rem;
   cursor: pointer;
-  transition: transform 0.4s ease, box-shadow 0.4s ease;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
   position: relative;
   overflow: hidden;
 }
@@ -289,29 +400,89 @@ section header > p {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(191, 163, 85, 0.35), transparent 60%);
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.3), transparent 65%);
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--transition);
 }
 
 .benefit-card:hover {
   transform: translateY(-6px);
-  box-shadow: var(--shadow);
+  box-shadow: 0 24px 44px rgba(8, 47, 73, 0.35);
+  border-color: rgba(56, 189, 248, 0.4);
 }
 
 .benefit-card:hover::after {
   opacity: 1;
 }
 
+.section-card {
+  background: rgba(7, 13, 26, 0.82);
+  padding: clamp(1.8rem, 4vw, 2.6rem);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.offer-cards,
+.contact-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.card {
+  background: rgba(7, 13, 26, 0.85);
+  border-radius: calc(var(--radius) - 10px);
+  padding: 1.6rem;
+  box-shadow: 0 14px 28px rgba(3, 7, 18, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 20px 40px rgba(3, 7, 18, 0.45);
+  border-color: rgba(56, 189, 248, 0.35);
+}
+
+.card p {
+  margin: 0;
+}
+
+.contact-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.contact-card span {
+  color: var(--muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.contact-card a {
+  color: var(--fg);
+  font-weight: 600;
+  word-break: break-word;
+  transition: color var(--transition);
+}
+
+.contact-card a:hover {
+  color: var(--accent);
+}
+
 .modal {
   position: fixed;
   inset: 0;
-  background: rgba(12, 12, 15, 0.8);
+  background: rgba(3, 7, 18, 0.78);
   display: none;
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
   z-index: 950;
+  backdrop-filter: blur(6px);
 }
 
 .modal.show {
@@ -319,9 +490,9 @@ section header > p {
 }
 
 .modal-content {
-  background: #101014;
-  border: 1px solid var(--border);
-  border-radius: 1rem;
+  background: rgba(8, 16, 31, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: calc(var(--radius) - 8px);
   max-width: 420px;
   width: 100%;
   padding: 2rem;
@@ -335,12 +506,18 @@ section header > p {
   color: var(--fg);
   font-size: 1.5rem;
   cursor: pointer;
+  transition: color var(--transition);
+}
+
+.close-modal:hover,
+.close-chat:hover {
+  color: var(--accent);
 }
 
 .timeline-track {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
+  gap: 1.6rem;
   position: relative;
 }
 
@@ -351,15 +528,15 @@ section header > p {
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, rgba(191, 163, 85, 0.6), transparent);
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.5), transparent);
   transform: translateY(-100%);
 }
 
 .timeline-step {
-  padding: 1.5rem;
-  border-radius: 1.25rem;
-  background: rgba(20, 20, 24, 0.85);
-  border: 1px solid var(--border);
+  padding: 1.6rem;
+  border-radius: calc(var(--radius) - 8px);
+  background: rgba(7, 13, 26, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.24);
   position: relative;
   overflow: hidden;
 }
@@ -370,20 +547,28 @@ section header > p {
   top: 1rem;
   inset-inline-end: 1rem;
   font-size: 2rem;
-  color: rgba(191, 163, 85, 0.3);
+  color: rgba(56, 189, 248, 0.25);
 }
 
 .faq details {
-  background: rgba(16, 16, 20, 0.9);
-  border: 1px solid var(--border);
+  background: rgba(7, 13, 26, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 1rem;
   padding: 1rem 1.5rem;
   margin-bottom: 1rem;
+  transition: border-color var(--transition), background var(--transition);
+}
+
+.faq details[open] {
+  border-color: rgba(56, 189, 248, 0.4);
+  background: rgba(8, 16, 31, 0.9);
 }
 
 .faq summary {
   cursor: pointer;
   font-weight: 700;
+  color: var(--fg);
+  outline: none;
 }
 
 .calculator input,
@@ -397,16 +582,25 @@ form button {
 .calculator input,
 form input,
 form select {
-  background: rgba(20, 20, 24, 0.8);
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  padding: 0.75rem 1rem;
+  background: rgba(9, 18, 32, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.85rem;
+  padding: 0.8rem 1rem;
   color: var(--fg);
   font-size: 1rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.calculator input:focus,
+form input:focus,
+form select:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.15);
 }
 
 .form-row {
-  margin-bottom: 1rem;
+  margin-bottom: 1.1rem;
 }
 
 .form-row.checkbox {
@@ -415,8 +609,9 @@ form select {
 
 .form-row.checkbox label {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.6rem;
   align-items: center;
+  color: var(--muted);
 }
 
 .calculator .result,
@@ -427,16 +622,16 @@ form select {
 }
 
 .vip-progress {
-  background: rgba(20, 20, 24, 0.8);
+  background: rgba(9, 18, 32, 0.85);
   border-radius: 999px;
-  border: 1px solid var(--border);
+  border: 1px solid rgba(148, 163, 184, 0.22);
   height: 12px;
   overflow: hidden;
   margin: 1rem 0;
 }
 
 .vip-progress-bar {
-  background: linear-gradient(90deg, rgba(191, 163, 85, 0.9), rgba(255, 255, 255, 0.5));
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.8));
   height: 100%;
   width: 0;
   transition: width 0.6s ease;
@@ -444,9 +639,9 @@ form select {
 
 .carousel {
   overflow: hidden;
-  border-radius: 1.5rem;
-  border: 1px solid var(--border);
-  background: rgba(16, 16, 20, 0.85);
+  border-radius: calc(var(--radius) - 6px);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(7, 13, 26, 0.85);
 }
 
 .carousel-track {
@@ -465,6 +660,7 @@ form select {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  color: var(--fg);
 }
 
 .testimonial blockquote {
@@ -483,16 +679,26 @@ form select {
   margin: 0.5rem 0;
 }
 
+.contact-lines a {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.contact-lines a:hover {
+  color: var(--accent-hover);
+}
+
 .site-footer {
-  background: rgba(12, 12, 15, 0.95);
-  border-top: 1px solid var(--border);
-  padding: 2rem clamp(1rem, 4vw, 3rem);
+  background: rgba(5, 11, 20, 0.95);
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 2.5rem clamp(1.25rem, 4vw, 3rem) 2rem;
 }
 
 .footer-content {
   display: grid;
   gap: 0.75rem;
   color: var(--muted);
+  text-align: center;
 }
 
 .chat-widget {
@@ -506,18 +712,23 @@ form select {
 }
 
 .chat-toggle {
-  background: var(--gold);
-  color: #000;
+  background: var(--accent);
+  color: #0f172a;
   border: none;
   border-radius: 999px;
   padding: 0.85rem 1.25rem;
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 0 15px 30px rgba(191, 163, 85, 0.35);
-  transition: transform 0.4s ease;
+  box-shadow: 0 18px 30px rgba(56, 189, 248, 0.25);
+  transition: transform var(--transition), box-shadow var(--transition);
   animation: float-in 1s ease forwards;
   opacity: 0;
   transform: translateY(20px);
+}
+
+.chat-toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 36px rgba(14, 165, 233, 0.3);
 }
 
 .chat-widget.open .chat-toggle {
@@ -532,8 +743,8 @@ form select {
 .chat-window {
   display: none;
   width: min(320px, 80vw);
-  background: rgba(16, 16, 20, 0.95);
-  border: 1px solid var(--border);
+  background: rgba(7, 13, 26, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.24);
   border-radius: 1rem 1rem 0.5rem 1rem;
   margin-top: 0.5rem;
   box-shadow: var(--shadow);
@@ -545,7 +756,7 @@ form select {
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem;
-  background: rgba(191, 163, 85, 0.1);
+  background: rgba(14, 165, 233, 0.12);
 }
 
 .chat-body {
@@ -563,20 +774,20 @@ form select {
   position: sticky;
   bottom: 0;
   width: 100%;
-  background: rgba(191, 163, 85, 0.2);
+  background: rgba(14, 165, 233, 0.15);
   color: var(--fg);
   text-align: center;
-  padding: 0.5rem 1rem;
+  padding: 0.6rem 1.2rem;
   font-size: 0.85rem;
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(10px);
 }
 
 .regulation-note {
   margin-top: 2rem;
   padding: 1rem;
-  border-radius: 0.75rem;
-  background: rgba(16, 16, 20, 0.85);
-  border: 1px dashed rgba(191, 163, 85, 0.4);
+  border-radius: 0.85rem;
+  background: rgba(7, 13, 26, 0.85);
+  border: 1px dashed rgba(56, 189, 248, 0.35);
   font-size: 0.85rem;
   color: var(--muted);
 }
@@ -590,6 +801,31 @@ form select {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (min-width: 640px) {
+  .cards-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .contact {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .hero {
+    grid-template-columns: 1.1fr 0.9fr;
+    align-items: center;
+  }
+
+  .cards-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .contact {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -638,10 +874,10 @@ body.lang-en .chat-widget.open .chat-window {
 }
 
 ::-webkit-scrollbar-track {
-  background: rgba(12, 12, 15, 0.7);
+  background: rgba(7, 13, 26, 0.85);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(191, 163, 85, 0.6);
+  background: rgba(56, 189, 248, 0.55);
   border-radius: 999px;
 }


### PR DESCRIPTION
## Summary
- refresh the global theme tokens with a new blue accent palette and typography choices
- restyle the hero, card grids, and modal surfaces with gradients, shadows, and responsive spacing
- align forms, chat widget, and footer elements with the updated design system

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691714ea1ddc832883c12db68c3fc5a1)